### PR TITLE
Using std::make_shared<T> instead of new

### DIFF
--- a/GameRepository.cc
+++ b/GameRepository.cc
@@ -5,10 +5,7 @@
 GameRepository gameRepository;
 
 GameRepository::~GameRepository() {
-    std::cout << "Invoke ~GameRepository" << std::endl;
-    for (auto it = storage.begin(); it != storage.end(); ++it) {
-        delete it->second;
-    }
+    storage.clear();
 }
 
 
@@ -17,18 +14,18 @@ const std::string randomId() {
     return std::to_string(rand());
 }
 
-Game *GameRepository::create(std::string playerName) {
-    Game *game = new Game();
+std::shared_ptr<Game> GameRepository::create(std::string playerName) {
+    std::shared_ptr<Game> game = std::make_shared<Game>();
     game->id = randomId();
     game->playerName = playerName;
     storage[game->id] = game;
     return game;
 }
 
-Game *GameRepository::findGameById(std::string gameId) {
+std::shared_ptr<Game> GameRepository::findGameById(std::string gameId) {
     return storage[gameId];
 }
 
-void GameRepository::save(Game *game) {
+void GameRepository::save(std::shared_ptr<Game> game) {
     // do nothing, there are all in the memory
 }

--- a/GameRepository.h
+++ b/GameRepository.h
@@ -7,16 +7,16 @@
 class GameRepository {
 
 private:
-    std::map<std::string, Game *> storage;
+    std::map<std::string, std::shared_ptr<Game>> storage;
 
 public:
     ~GameRepository();
 
-    Game *create(std::string playerName);
+    std::shared_ptr<Game> create(std::string playerName);
 
-    Game *findGameById(std::string gameId);
+    std::shared_ptr<Game> findGameById(std::string gameId);
 
-    void save(Game *game);
+    void save(std::shared_ptr<Game> game);
 };
 
 extern GameRepository gameRepository;

--- a/Models.cc
+++ b/Models.cc
@@ -5,10 +5,6 @@
 #include "Models.h"
 
 Game::~Game() {
-    std::cout << "~Game() " << this << std::endl;
-    for (auto it = history.begin(); it != history.end(); ++it) {
-        delete *it;
-    }
     history.clear();
 }
 
@@ -17,7 +13,7 @@ Game::Game() {
 }
 
 bool Game::guessNumber(int number) {
-    Record *r = new Record;
+    auto r = std::make_shared<Record>();
     r->guess = number;
     r->respond = createRespond(this->answer, number);
     history.push_back(r);

--- a/Models.h
+++ b/Models.h
@@ -15,7 +15,7 @@ public:
     std::string id;
     std::string playerName;
     int answer;
-    std::list<Record *> history;
+    std::list<std::shared_ptr<Record>> history;
 
     Game();
 

--- a/UseCases.cc
+++ b/UseCases.cc
@@ -11,12 +11,12 @@ CreateGameInput::CreateGameInput(string playerName) {
 
 void CreateGameUseCase::execute(CreateGameInput input, Output &output) {
     // 用 repo 查改存推
-    Game *game = gameRepository.create(input.playerName);
+    auto game = gameRepository.create(input.playerName);
     output.buildGameStatus(game);
 }
 
 
-void Output::buildGameStatus(Game *game) {
+void Output::buildGameStatus(std::shared_ptr<Game> game) {
     json history = json::array();
     for (const auto &record: game->history) {
         json entry;
@@ -35,7 +35,7 @@ string Output::to_json() {
 }
 
 void GuessNumberUseCase::execute(GuessNumberInput input, Output &output) {
-    Game *game = gameRepository.findGameById(input.gameId);
+    std::shared_ptr<Game> game = gameRepository.findGameById(input.gameId);
     game->guessNumber(input.number);
     gameRepository.save(game);
     output.buildGameStatus(game);

--- a/UseCases.h
+++ b/UseCases.h
@@ -20,7 +20,7 @@ private:
     string gameStatus;
 
 public:
-    void buildGameStatus(Game *game);
+    void buildGameStatus(std::shared_ptr<Game> game);
 
     string to_json();
 };

--- a/test/test_main.cc
+++ b/test/test_main.cc
@@ -93,7 +93,7 @@ DROGON_TEST(GameAPITest) {
 
     {
         // arrange the final answer
-        Game *game = gameRepository.findGameById(gameId);
+        std::shared_ptr<Game> game = gameRepository.findGameById(gameId);
         game->answer = 1234;
 
         auto resp = http_post("/guess_number_game:guess",


### PR DESCRIPTION

https://ithelp.ithome.com.tw/articles/10214337

> 「Modern C++」有一個寬鬆的要求：盡可能不要直接使用 new/delete 來建構物件或使用記憶體。遇到 new/delete 應該改用 std::make_unique 或者 std::make_shared 來取代。《[Effective Modern C++](https://lihi1.com/YGNMM)》Item 21 有說明理由。