### PR TITLE
Using jsoncpp instead of nlohmann/json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ endif ()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules/)
+
 file(GLOB web_src src/web/*.cc)
 add_executable(${PROJECT_NAME} main.cc ${web_src})
 add_dependencies(${PROJECT_NAME} repo)
@@ -28,8 +30,9 @@ add_subdirectory(src/repo)
 add_subdirectory(src/usecase)
 
 # add dependencies
-include(cmake/CPM.cmake)
-CPMAddPackage("gh:nlohmann/json@3.10.5")
+find_package(Jsoncpp REQUIRED)
+include_directories(${JSONCPP_INCLUDE_DIRS})
+
 
 # ##############################################################################
 # If you include the drogon source code locally in your project, use this method
@@ -39,7 +42,7 @@ CPMAddPackage("gh:nlohmann/json@3.10.5")
 #
 # and comment out the following lines
 find_package(Drogon CONFIG REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon nlohmann_json::nlohmann_json usecase)
+target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon Jsoncpp_lib usecase)
 
 # ##############################################################################
 

--- a/cmake/modules/FindJsoncpp.cmake
+++ b/cmake/modules/FindJsoncpp.cmake
@@ -1,0 +1,70 @@
+# Find jsoncpp
+#
+# Find the jsoncpp includes and library
+#
+# if you nee to add a custom library search path, do it via via
+# CMAKE_PREFIX_PATH
+#
+# This module defines JSONCPP_INCLUDE_DIRS, where to find header, etc.
+# JSONCPP_LIBRARIES, the libraries needed to use jsoncpp. JSONCPP_FOUND, If
+# false, do not try to use jsoncpp.
+# Jsoncpp_lib - The imported target library.
+
+# only look in default directories
+find_path(JSONCPP_INCLUDE_DIRS
+          NAMES json/json.h
+          DOC "jsoncpp include dir"
+          PATH_SUFFIXES jsoncpp)
+
+find_library(JSONCPP_LIBRARIES NAMES jsoncpp DOC "jsoncpp library")
+
+# debug library on windows same naming convention as in qt (appending debug
+# library with d) boost is using the same "hack" as us with "optimized" and
+# "debug" if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+# find_library(JSONCPP_LIBRARIES_DEBUG NAMES jsoncppd DOC "jsoncpp debug
+# library") if("${JSONCPP_LIBRARIES_DEBUG}" STREQUAL "JSONCPP_LIBRARIES_DEBUG-
+# NOTFOUND") set(JSONCPP_LIBRARIES_DEBUG ${JSONCPP_LIBRARIES}) endif()
+
+# set(JSONCPP_LIBRARIES optimized ${JSONCPP_LIBRARIES} debug
+# ${JSONCPP_LIBRARIES_DEBUG})
+
+# endif()
+
+# handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE if all
+# listed variables are TRUE, hide their existence from configuration view
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Jsoncpp
+                                  DEFAULT_MSG
+                                  JSONCPP_INCLUDE_DIRS
+                                  JSONCPP_LIBRARIES)
+mark_as_advanced(JSONCPP_INCLUDE_DIRS JSONCPP_LIBRARIES)
+
+if(Jsoncpp_FOUND)
+  if(NOT EXISTS ${JSONCPP_INCLUDE_DIRS}/json/version.h)
+    message(FATAL_ERROR "Error: jsoncpp lib is too old.....stop")
+  endif()
+  if(NOT WIN32)
+    exec_program(
+      cat
+      ARGS
+      "${JSONCPP_INCLUDE_DIRS}/json/version.h |grep JSONCPP_VERSION_STRING|sed s'/.*define/define/'|awk '{printf $3}'|sed s'/\"//g'"
+      OUTPUT_VARIABLE
+      jsoncpp_ver)
+    message(STATUS "jsoncpp verson:" ${jsoncpp_ver})
+    if(jsoncpp_ver LESS 1.7)
+      message(
+        FATAL_ERROR
+          "jsoncpp lib is too old, please get new version from https://github.com/open-source-parsers/jsoncpp"
+        )
+    endif(jsoncpp_ver LESS 1.7)
+  endif()
+  if (NOT TARGET Jsoncpp_lib)
+          add_library(Jsoncpp_lib INTERFACE IMPORTED)
+  endif()
+  set_target_properties(Jsoncpp_lib
+                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                   "${JSONCPP_INCLUDE_DIRS}"
+                                   INTERFACE_LINK_LIBRARIES
+                                   "${JSONCPP_LIBRARIES}")
+
+endif(Jsoncpp_FOUND)

--- a/cmake/modules/FindJsoncpp.cmake.LICENSE
+++ b/cmake/modules/FindJsoncpp.cmake.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2021 An Tao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmake/modules/README
+++ b/cmake/modules/README
@@ -1,0 +1,2 @@
+
+* The FindJsoncpp.cmake is copied from https://github.com/drogonframework/drogon/blob/master/cmake_modules/FindJsoncpp.cmake

--- a/src/usecase/CMakeLists.txt
+++ b/src/usecase/CMakeLists.txt
@@ -1,10 +1,9 @@
 file(GLOB usecase_src *.cc)
 
 # add dependencies
-include(../../cmake/CPM.cmake)
-CPMAddPackage("gh:nlohmann/json@3.10.5")
-
+find_package(Jsoncpp REQUIRED)
+include_directories(${JSONCPP_INCLUDE_DIRS})
 
 add_library(usecase ${usecase_src})
-target_link_libraries(usecase PRIVATE nlohmann_json::nlohmann_json repo model)
+target_link_libraries(usecase PRIVATE Jsoncpp_lib repo model)
 add_dependencies(usecase repo)

--- a/src/usecase/GuessNumber.cc
+++ b/src/usecase/GuessNumber.cc
@@ -1,9 +1,8 @@
 #include "GuessNumber.h"
-#include "nlohmann/json.hpp"
+#include <json/json.h>
 #include "../repo/GameRepository.h"
 
 using namespace std;
-using json = nlohmann::json;
 
 
 void GuessNumberUseCase::execute(GuessNumberInput input, Output &output) {

--- a/src/usecase/common.cc
+++ b/src/usecase/common.cc
@@ -1,25 +1,26 @@
 #include "common.h"
-#include <nlohmann/json.hpp>
-
-using json = nlohmann::json;
+#include <json/json.h>
 
 void Output::buildGameStatus(std::shared_ptr<Game> game) {
-    json history = json::array();
+    Json::Value history(Json::arrayValue);
     for (const auto &record: game->history) {
-        json entry;
+        Json::Value entry;
         entry["guess"] = record->guess;
         entry["respond"] = record->respond;
-        history.push_back(entry);
+        history.append(entry);
     }
 
-    this->gameStatus = json{{"game_id",     game->id},
-                            {"player_name", game->playerName},
-                            {"won",         game->won},
-                            {"history",     history},
-    };
+    Json::Value status;
+    status["game_id"] = game->id;
+    status["player_name"] = game->playerName;
+    status["won"] = game->won;
+    status["history"] = history;
 
+    this->gameStatus = status;
 }
 
 std::string Output::to_json() {
-    return this->gameStatus.dump();
+    Json::FastWriter writer;
+    std::string json_str = writer.write(this->gameStatus);
+    return json_str;
 }

--- a/src/usecase/common.h
+++ b/src/usecase/common.h
@@ -3,14 +3,13 @@
 #include <string>
 #include <memory>
 #include "../model/Game.h"
-#include <nlohmann/json.hpp>
+#include <json/json.h>
 
-using json = nlohmann::json;
 
 class Output {
 
 public:
-    json gameStatus;
+    Json::Value gameStatus;
 
 public:
     void buildGameStatus(std::shared_ptr<Game> game);

--- a/src/web/CreateGameCtrl.cc
+++ b/src/web/CreateGameCtrl.cc
@@ -1,11 +1,8 @@
 #include "CreateGameCtrl.h"
 #include "../usecase/GuessNumber.h"
-#include "nlohmann/json.hpp"
+#include <json/json.h>
 #include "../usecase/CreateGame.h"
 #include "common.h"
-
-
-using json = nlohmann::json;
 
 
 void CreateGameCtrl::asyncHandleHttpRequest(const HttpRequestPtr &req,
@@ -13,8 +10,15 @@ void CreateGameCtrl::asyncHandleHttpRequest(const HttpRequestPtr &req,
     CreateGameUseCase uc;
     Output output;
 
-    auto data = json::parse(req->getBody());
-    uc.execute(CreateGameInput(data["player_name"]), output);
+
+    Json::Value data;
+    Json::Reader reader;
+    bool parsed = reader.parse(std::string(req->getBody()), data);
+    if (!parsed) {
+        // TODO handle parsing error
+    }
+
+    uc.execute(CreateGameInput(data["player_name"].asString()), output);
     callback(newJsonResponse(output.to_json()));
 }
 

--- a/src/web/GuessNumberCtrl.cc
+++ b/src/web/GuessNumberCtrl.cc
@@ -7,8 +7,13 @@ void GuessNumberCtrl::asyncHandleHttpRequest(const drogon::HttpRequestPtr &req,
     GuessNumberUseCase uc;
     Output output;
 
+    Json::Value data;
+    Json::Reader reader;
+    bool parsed = reader.parse(std::string(req->getBody()), data);
+    if (!parsed) {
+        // TODO handle parsing error
+    }
 
-    auto data = nlohmann::json::parse(req->getBody());
-    uc.execute(GuessNumberInput(data["game_id"], data["number"]), output);
+    uc.execute(GuessNumberInput(data["game_id"].asString(), data["number"].asInt()), output);
     callback(newJsonResponse(output.to_json()));
 }

--- a/src/web/GuessNumberCtrl.h
+++ b/src/web/GuessNumberCtrl.h
@@ -2,7 +2,6 @@
 
 #include <drogon/HttpSimpleController.h>
 #include "../repo/GameRepository.h"
-#include "nlohmann/json.hpp"
 #include "../usecase/GuessNumber.h"
 
 class GuessNumberCtrl : public drogon::HttpSimpleController<GuessNumberCtrl> {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,8 @@ file(GLOB web_src ../src/web/*.cc)
 add_executable(${PROJECT_NAME} test_main.cc ${web_src})
 
 # add dependencies
-include(../cmake/CPM.cmake)
-CPMAddPackage("gh:nlohmann/json@3.10.5")
+find_package(Jsoncpp REQUIRED)
+include_directories(${JSONCPP_INCLUDE_DIRS})
 
 # ##############################################################################
 # If you include the drogon source code locally in your project, use this method
@@ -18,6 +18,6 @@ CPMAddPackage("gh:nlohmann/json@3.10.5")
 # and comment out the following lines
 
 
-target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon nlohmann_json::nlohmann_json usecase)
+target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon Jsoncpp_lib usecase)
 
 ParseAndAddDrogonTests(${PROJECT_NAME})

--- a/test_client/CMakeLists.txt
+++ b/test_client/CMakeLists.txt
@@ -3,9 +3,4 @@ project(gaas_console CXX)
 
 
 add_executable(${PROJECT_NAME} console.cc)
-
-# add dependencies
-include(../cmake/CPM.cmake)
-CPMAddPackage("gh:nlohmann/json@3.10.5")
-
-target_link_libraries(${PROJECT_NAME} PRIVATE usecase nlohmann_json::nlohmann_json)
+target_link_libraries(${PROJECT_NAME} PRIVATE usecase)

--- a/test_client/console.cc
+++ b/test_client/console.cc
@@ -1,7 +1,6 @@
 #include <iostream>
 #include "../src/usecase/CreateGame.h"
 #include "../src/usecase/GuessNumber.h"
-#include <nlohmann/json.hpp>
 
 
 void game_loop();
@@ -61,7 +60,7 @@ void showGuessRespond(Output &output, const string &gameId, const pair<bool, int
     return;
 }
 
-bool isGameFinished(const Output &output) { return output.gameStatus["won"]; }
+bool isGameFinished(const Output &output) { return output.gameStatus["won"].asBool(); }
 
 std::string startGame(Output &output) {
     string playerName = "";
@@ -73,7 +72,7 @@ std::string startGame(Output &output) {
     createGameUseCase.execute(CreateGameInput(playerName), output);
     cout << "Hi, " << output.gameStatus["player_name"] << endl;
 
-    return output.gameStatus["game_id"];
+    return output.gameStatus["game_id"].asString();
 }
 
 bool isInteger(const std::string &str) {


### PR DESCRIPTION
Because `jsoncpp` is required by the Drogon Framework, it needn't introduce another json library.